### PR TITLE
M #-: update management cluster resources to fit new upstream sylva-core

### DIFF
--- a/scenario/deploy/kubeadm/mgmt/my-kubeadm-capone/values.yaml
+++ b/scenario/deploy/kubeadm/mgmt/my-kubeadm-capone/values.yaml
@@ -26,7 +26,39 @@ cluster:
             SET_HOSTNAME = "$NAME",
             SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
             TOKEN = "NO" ]
-          CPU = "1"
+          CPU = "2"
+          CPU_MODEL = [
+            MODEL = "host-passthrough" ]
+          DISK = [
+            IMAGE = "capone-kubeadm-mgmt-node",
+            SIZE = "65536" ]
+          GRAPHICS = [
+            LISTEN = "0.0.0.0",
+            TYPE = "vnc" ]
+          HYPERVISOR = "kvm"
+          LXD_SECURITY_PRIVILEGED = "true"
+          MEMORY = "24576"
+          OS = [
+            ARCH = "x86_64",
+            FIRMWARE_SECURE = "YES" ]
+          SCHED_REQUIREMENTS = "HYPERVISOR=kvm"
+          VCPU = "16"
+          SCHED_ACTION = [
+            ACTION = "undeploy",
+            ID     = "0",
+            TIME   = "+7200" ]
+          SCHED_ACTION = [
+            ACTION = "terminate",
+            ID     = "1",
+            TIME   = "+57600" ]
+      - templateName: capone-kubeadm-mgmt-worker
+        templateContent: |
+          CONTEXT = [
+            NETWORK = "YES",
+            SET_HOSTNAME = "$NAME",
+            SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
+            TOKEN = "NO" ]
+          CPU = "2"
           CPU_MODEL = [
             MODEL = "host-passthrough" ]
           DISK = [
@@ -43,38 +75,6 @@ cluster:
             FIRMWARE_SECURE = "YES" ]
           SCHED_REQUIREMENTS = "HYPERVISOR=kvm"
           VCPU = "8"
-          SCHED_ACTION = [
-            ACTION = "undeploy",
-            ID     = "0",
-            TIME   = "+7200" ]
-          SCHED_ACTION = [
-            ACTION = "terminate",
-            ID     = "1",
-            TIME   = "+57600" ]
-      - templateName: capone-kubeadm-mgmt-worker
-        templateContent: |
-          CONTEXT = [
-            NETWORK = "YES",
-            SET_HOSTNAME = "$NAME",
-            SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
-            TOKEN = "NO" ]
-          CPU = "1"
-          CPU_MODEL = [
-            MODEL = "host-passthrough" ]
-          DISK = [
-            IMAGE = "capone-kubeadm-mgmt-node",
-            SIZE = "65536" ]
-          GRAPHICS = [
-            LISTEN = "0.0.0.0",
-            TYPE = "vnc" ]
-          HYPERVISOR = "kvm"
-          LXD_SECURITY_PRIVILEGED = "true"
-          MEMORY = "6144"
-          OS = [
-            ARCH = "x86_64",
-            FIRMWARE_SECURE = "YES" ]
-          SCHED_REQUIREMENTS = "HYPERVISOR=kvm"
-          VCPU = "4"
           SCHED_ACTION = [
             ACTION = "undeploy",
             ID     = "0",

--- a/scenario/deploy/rke2/mgmt/my-rke2-capone/values.yaml
+++ b/scenario/deploy/rke2/mgmt/my-rke2-capone/values.yaml
@@ -24,7 +24,39 @@ cluster:
             SET_HOSTNAME = "$NAME",
             SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
             TOKEN = "NO" ]
-          CPU = "1"
+          CPU = "2"
+          CPU_MODEL = [
+            MODEL = "host-passthrough" ]
+          DISK = [
+            IMAGE = "capone-rke2-mgmt-node",
+            SIZE = "65536" ]
+          GRAPHICS = [
+            LISTEN = "0.0.0.0",
+            TYPE = "vnc" ]
+          HYPERVISOR = "kvm"
+          LXD_SECURITY_PRIVILEGED = "true"
+          MEMORY = "24576"
+          OS = [
+            ARCH = "x86_64",
+            FIRMWARE_SECURE = "YES" ]
+          SCHED_REQUIREMENTS = "HYPERVISOR=kvm"
+          VCPU = "16"
+          SCHED_ACTION = [
+            ACTION = "undeploy",
+            ID     = "0",
+            TIME   = "+7200" ]
+          SCHED_ACTION = [
+            ACTION = "terminate",
+            ID     = "1",
+            TIME   = "+57600" ]
+      - templateName: capone-rke2-mgmt-worker
+        templateContent: |
+          CONTEXT = [
+            NETWORK = "YES",
+            SET_HOSTNAME = "$NAME",
+            SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
+            TOKEN = "NO" ]
+          CPU = "2"
           CPU_MODEL = [
             MODEL = "host-passthrough" ]
           DISK = [
@@ -41,38 +73,6 @@ cluster:
             FIRMWARE_SECURE = "YES" ]
           SCHED_REQUIREMENTS = "HYPERVISOR=kvm"
           VCPU = "8"
-          SCHED_ACTION = [
-            ACTION = "undeploy",
-            ID     = "0",
-            TIME   = "+7200" ]
-          SCHED_ACTION = [
-            ACTION = "terminate",
-            ID     = "1",
-            TIME   = "+57600" ]
-      - templateName: capone-rke2-mgmt-worker
-        templateContent: |
-          CONTEXT = [
-            NETWORK = "YES",
-            SET_HOSTNAME = "$NAME",
-            SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
-            TOKEN = "NO" ]
-          CPU = "1"
-          CPU_MODEL = [
-            MODEL = "host-passthrough" ]
-          DISK = [
-            IMAGE = "capone-rke2-mgmt-node",
-            SIZE = "65536" ]
-          GRAPHICS = [
-            LISTEN = "0.0.0.0",
-            TYPE = "vnc" ]
-          HYPERVISOR = "kvm"
-          LXD_SECURITY_PRIVILEGED = "true"
-          MEMORY = "6144"
-          OS = [
-            ARCH = "x86_64",
-            FIRMWARE_SECURE = "YES" ]
-          SCHED_REQUIREMENTS = "HYPERVISOR=kvm"
-          VCPU = "4"
           SCHED_ACTION = [
             ACTION = "undeploy",
             ID     = "0",


### PR DESCRIPTION
Tested by checking out my fork and the b-588-resources branch on the Sylva CI VM, and let the nightly tests to execute via them:

<img width="1406" height="643" alt="image" src="https://github.com/user-attachments/assets/57a675dd-27f7-4f10-bf25-3fe1d220f2b7" />


To finalize this contribution and keep only master branch in the Sylva CI VM, let's merge this.

